### PR TITLE
changed TCM to be standalone instead of Graph subclass

### DIFF
--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -2,7 +2,7 @@ from flask import Flask, render_template
 from app.routes.main import main_bp
 from app.routes.api import api_bp
 from pathlib import Path
-from src.loader import build_graph
+from src.loader import build_graph, build_tcm
 
 
 def create_app(test_config=None):
@@ -10,6 +10,7 @@ def create_app(test_config=None):
 
     try:
         app.config["COURSE_GRAPH"] = build_graph()
+        app.config["COURSE_TCM"] = build_tcm()
     except Exception as e:
         app.logger.error(f"Failed to build course graph: {e}")
         raise RuntimeError("App init failed due to course graph error") from e

--- a/server/app/routes/main.py
+++ b/server/app/routes/main.py
@@ -43,7 +43,10 @@ def unlocks_page(code: str):
         abort(404, "Bad course code")
 
     graph = current_app.config["COURSE_GRAPH"]
-    unlocked = sorted(graph.getAdjList().get(base, []))
+    try:
+        unlocked = sorted(graph.postreqs(base))  #all downstream courses
+    except ValueError:
+        abort(404, f"{base} not found in catalog")
     #shows empty list
     return render_template("unlocks.html",
                            title=f"{base} unlocks…",

--- a/server/app/templates/unlocks.html
+++ b/server/app/templates/unlocks.html
@@ -5,87 +5,26 @@
   <meta charset="utf-8" />
   <title>{{ title }}</title>
   <style>
-    .course-item { margin-bottom: 0.5em; cursor: pointer; }
-    .children-list { margin-left: 0.75em; margin-top: 0.25em; list-style-type: disc; }
-    .toggle { margin-right: 0.5em; }
+    body { font-family: sans-serif; max-width: 40rem; margin: 2rem auto; }
+    ul { padding-left: 1.25rem; }
   </style>
 </head>
 <body>
   {% include 'nav_header.html' %}
 
-  <h1>Courses unlocked by {{ code }}</h1>
+  <h1>All courses unlocked by {{ code }}</h1>
 
   {% if unlocked %}
-  <ul id="postreq-tree">
-    {% for course in unlocked %}
-      <li class="course-item" data-code="{{ course }}">
-        <span class="toggle">[+]</span>
-        <span class="course-name">{{ course }}</span>
-        <ul class="children-list" style="display:none;"></ul>
-      </li>
-    {% endfor %}
-  </ul>
+    <p><strong>Total:</strong> {{ unlocked|length }}</p>
+    <ul>
+      {% for course in unlocked %}
+        <li>{{ course }}</li>
+      {% endfor %}
+    </ul>
   {% else %}
-    <p><em>No courses found.</em></p>
+    <p><em>No courses depend on {{ code }}.</em></p>
   {% endif %}
 
   <p><a href="{{ url_for('main.index') }}">← back</a></p>
-
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const tree = document.getElementById('postreq-tree');
-
-      tree.addEventListener('click', async (e) => {
-        const li = e.target.closest('.course-item');
-        if (!li) return;
-        e.stopPropagation();
-
-        const toggle = li.querySelector('.toggle');
-        const sublist = li.querySelector('.children-list');
-
-        // fetch only once per node
-        if (!li.dataset.loaded) {
-          const code = li.dataset.code;
-          try {
-            const res = await fetch(`/api/unlocks/${code}`);
-            if (!res.ok) throw new Error(res.statusText);
-            const children = await res.json();
-            if (children.length) {
-              children.forEach(child => {
-                const childLi = document.createElement('li');
-                childLi.className = 'course-item';
-                childLi.dataset.code = child;
-                childLi.innerHTML = `
-                  <span class="toggle">[+]</span>
-                  <span class="course-name">${child}</span>
-                  <ul class="children-list" style="display:none;"></ul>
-                `;
-                sublist.appendChild(childLi);
-              });
-            } else {
-              const liEmpty = document.createElement('li');
-              liEmpty.innerHTML = '<em>No further unlocks</em>';
-              sublist.appendChild(liEmpty);
-            }
-          } catch (err) {
-            console.error(err);
-            const liErr = document.createElement('li');
-            liErr.innerHTML = '<em>Failed to load.</em>';
-            sublist.appendChild(liErr);
-          }
-          li.dataset.loaded = 'true';
-        }
-
-        // toggle visibility
-        if (sublist.style.display === 'none') {
-          sublist.style.display = 'block';
-          toggle.textContent = '[-]';
-        } else {
-          sublist.style.display = 'none';
-          toggle.textContent = '[+]';
-        }
-      });
-    });
-  </script>
 </body>
 </html>

--- a/server/src/graph.py
+++ b/server/src/graph.py
@@ -47,16 +47,3 @@ class Graph:
 
         v.remove(root)
         return v
-
-
-class TCM(Graph):  # transitive closure map maintains postreqs for EVERY class
-    def __init__(self, adj_list=None):
-        super().__init__()
-        if adj_list:
-            self.adj_list = adj_list.copy()
-
-    def closure(self):
-        closure = {}
-        for course in self.adj_list:
-            closure[course] = self.postreqs(course)
-        return closure

--- a/server/src/loader.py
+++ b/server/src/loader.py
@@ -1,6 +1,7 @@
 import json, re
 from pathlib import Path
 from .graph import Graph
+from .tcm import TCM
 
 _JSON_PATH = Path(__file__).parent / "json" / "soc_cleaned.json"
 _COURSE_RE = re.compile(r"\b[A-Z]{3,4}\s?\d{4}[A-Z]?\b")
@@ -19,3 +20,9 @@ def build_graph() -> Graph:
         for p in _extract_codes(c.get("prerequisites", "")):
             g.insertEdge(p.upper(), tgt)
     return g
+
+def build_tcm() -> TCM:
+    graph = build_graph()
+    tcm = TCM.from_graph(graph)
+    return tcm
+

--- a/server/src/tcm.py
+++ b/server/src/tcm.py
@@ -1,0 +1,18 @@
+from collections.abc import Mapping
+from .graph import Graph
+
+class TCM:
+    def __init__(self, closure: Mapping[str, set[str]]):
+        self._map: dict[str, set[str]] = dict(closure)
+
+    @classmethod
+    def from_graph(cls, g: Graph) -> "TCM":
+        closure: dict[str, set[str]] = {}
+        for course in g.getAdjList():
+            downstream = g.postreqs(course)
+            closure[course] = downstream
+
+        return cls(closure)
+
+    def postreqs(self, code: str) -> set[str]:
+        return self._map.get(code.upper(), set())

--- a/server/tests/test_graph.py
+++ b/server/tests/test_graph.py
@@ -3,7 +3,7 @@ Tests for graph implementation with UF data
 Run this test with `python -m pytest tests/test_graph.py`
 """
 
-from src.graph import Graph, TCM
+from src.graph import Graph
 import pdb
 
 
@@ -80,20 +80,3 @@ def test_postreqs(complex_g):
     expected_postreqs = {"MAC2312", "COT3100", "COP3503", "COP3530"}
     postreqs = complex_g.postreqs(root)
     assert postreqs == expected_postreqs
-
-
-def test_tcm(complex_g):
-    tcm = TCM(complex_g.adj_list)
-    
-    expected_closure = {
-        "COP3530": set(),
-        "COP3504": {"COP3530"},
-        "COP3503": {"COP3530"},
-        "COT3100": {"COP3530"},
-        "MAC2312": {"COP3530"},
-        "COP3502": {"COP3503", "COT3100", "COP3530"},
-        "MAC3472": {"MAC2312", "COT3100", "COP3530"},
-        "MAC2311": {"MAC2312", "COT3100", "COP3503", "COP3530"},
-    }
-    closure = tcm.closure()
-    assert closure == expected_closure

--- a/server/tests/test_tcm.py
+++ b/server/tests/test_tcm.py
@@ -1,0 +1,10 @@
+from src.tcm import TCM, Graph
+
+def test_tcm_matches_graph(complex_g: Graph):
+    tcm = TCM.from_graph(complex_g)
+    for course in complex_g.getAdjList():
+        assert tcm.postreqs(course) == complex_g.postreqs(course)
+
+def test_tcm_missing_course():
+    tcm = TCM({})
+    assert tcm.postreqs("ABC") == set()

--- a/server/tests/test_tcm.py
+++ b/server/tests/test_tcm.py
@@ -1,4 +1,5 @@
-from src.tcm import TCM, Graph
+from src.tcm import TCM
+from src.graph import Graph
 
 def test_tcm_matches_graph(complex_g: Graph):
     tcm = TCM.from_graph(complex_g)


### PR DESCRIPTION
-TCM class postreqs("code") function should return same set as Graph class postreqs("code")
-TCM class best built with TCM.from_graph(graph). This is done in loader.py build_tcm() helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the display of unlocked courses by showing a simple, complete list with a total count, replacing the previous interactive expandable tree.
  * Enhanced error handling for invalid course codes by providing clearer feedback when a course is not found.
  * Added a new transitive closure mapping to better represent course prerequisite relationships.

* **Bug Fixes**
  * Ensured consistent retrieval of downstream courses, improving reliability across the application.

* **Tests**
  * Added new tests for transitive closure mapping functionality and removed outdated tests to ensure accurate coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->